### PR TITLE
Set encoding of projects to UTF-8

### DIFF
--- a/net.sf.py4j.defaultserver.feature/.settings/org.eclipse.core.resources.prefs
+++ b/net.sf.py4j.defaultserver.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/net.sf.py4j.defaultserver/.settings/org.eclipse.core.resources.prefs
+++ b/net.sf.py4j.defaultserver/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/net.sf.py4j.example/.settings/org.eclipse.core.resources.prefs
+++ b/net.sf.py4j.example/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/net.sf.py4j.feature/.settings/org.eclipse.core.resources.prefs
+++ b/net.sf.py4j.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/net.sf.py4j.site/.settings/org.eclipse.core.resources.prefs
+++ b/net.sf.py4j.site/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/net.sf.py4j/.settings/org.eclipse.core.resources.prefs
+++ b/net.sf.py4j/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8


### PR DESCRIPTION
This fixes encoding for project containing UTFExample and sets the
encoding to match that of the submodules projects
